### PR TITLE
atts -> attr ...

### DIFF
--- a/DynatraceExtensions.cs
+++ b/DynatraceExtensions.cs
@@ -18,7 +18,7 @@ namespace Serilog
             int? queueLimit = null,
             TimeSpan? period = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string propertiesPrefix = "atts.")
+            string propertiesPrefix = "attr.")
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (string.IsNullOrWhiteSpace(accessToken)) throw new ArgumentNullException(nameof(accessToken));


### PR DESCRIPTION
all good ? in previous versions the usage pattern was attr. in this version it was changed and this caused some problems in many of our applications in total more than 50, can we return the default to attr ? I say this because in dynatrace we have to configure the filters one by one so we will have to configure new filters... and everyone who used this library too