### PR TITLE
commit for scalar null reference exception

### DIFF
--- a/DynatraceTextFormatter.cs
+++ b/DynatraceTextFormatter.cs
@@ -90,7 +90,7 @@ namespace Serilog.Sinks.Dynatrace
                         output.Write(",");
                         JsonValueFormatter.WriteQuotedJsonString(flatKey, output);
                         output.Write(':');
-                        JsonValueFormatter.WriteQuotedJsonString(scalar.Value.ToString(), output); // Only values of the String type are supported
+                        JsonValueFormatter.WriteQuotedJsonString(Convert.ToString(scalar.Value), output); // Only values of the String type are supported
                         break;
                     case SequenceValue sequence:
                         int seq = 0;


### PR DESCRIPTION
.ToString throws an exception if the object is null, therefore getting an error  in catch block  "Event at {0} with message template {1} could not be formatted into JSON and will be dropped: {2}""