### PR TITLE
feat: dont prefix dynatrace properties

### DIFF
--- a/DynatraceTextFormatter.cs
+++ b/DynatraceTextFormatter.cs
@@ -12,6 +12,7 @@ namespace Serilog.Sinks.Dynatrace
     class DynatraceTextFormatter : ITextFormatter
     {
         private static readonly string[] ROOT_PROPERTIES = { "trace_id", "span_id" }; // OpenTelemetry
+        private const string DYNATRACE_PREFIX = "dt.";
 
         private readonly string _applicationId;
         private readonly string _hostName;
@@ -90,7 +91,8 @@ namespace Serilog.Sinks.Dynatrace
             foreach (var property in properties)
             {
                 var flatKey = prefixKey + property.Key;
-                if (ROOT_PROPERTIES.Contains(property.Key)) flatKey = property.Key; 
+                if (ROOT_PROPERTIES.Contains(property.Key)) flatKey = property.Key;
+                if (property.Key.StartsWith(DYNATRACE_PREFIX)) flatKey = property.Key;
                 switch (property.Value) 
                 {
                     case ScalarValue scalar:


### PR DESCRIPTION
Stop prefixing properties that start with `dt.` like [dt.entity.process_group_instance](https://www.dynatrace.com/support/help/observe-and-explore/logs/log-monitoring/log-monitoring-configuration/log-enrichment#example-of-enriched-log-data-in-json-format) https://github.com/iojancode/Serilog.Sinks.Dynatrace/issues/10