### PR TITLE
Add attributes that should not be prefixed

### DIFF
--- a/DynatraceTextFormatter.cs
+++ b/DynatraceTextFormatter.cs
@@ -11,7 +11,20 @@ namespace Serilog.Sinks.Dynatrace
 {
     class DynatraceTextFormatter : ITextFormatter
     {
-        private static readonly string[] ROOT_PROPERTIES = { "trace_id", "span_id" }; // OpenTelemetry
+        // Needed by dynatrace as is. Should not be prefixed
+        private static readonly string[] ROOT_PROPERTIES = { 
+            // Trace specifics
+            "trace_id", 
+            "span_id",
+            "trace_sampled",
+
+            // Process specifics
+            "dt.entity.process_group_instance",
+
+            // Host specifics
+            "dt.entity.host",
+            "dt.host_group",
+            "dt.host_group.id"}; 
 
         private readonly string _applicationId;
         private readonly string _hostName;


### PR DESCRIPTION
Added more attributes that should not be prefixed to make dynatrace able to match it to specific traces.