### PR TITLE
Update `Serilog.Sinks.Http` and `Serilog` dependencies

### DIFF
--- a/DynatraceExtensions.cs
+++ b/DynatraceExtensions.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.Dynatrace;
+using Serilog.Sinks.Http;
 
 namespace Serilog
 {
@@ -16,8 +17,8 @@ namespace Serilog
         /// <param name="ingestUrl">The endpoint for log ingestion, usually of the form "https://{instanceId}.live.dynatrace.com/api/v2/logs/ingest"</param>
         /// <param name="applicationId">Will be populated as application.id in all log entries</param>
         /// <param name="hostName">Will be populated as host.name in all log entries</param>
-        /// <param name="batchPostingLimit">Serilog http sink pass-through</param>
-        /// <param name="queueLimit">Serilog http sink pass-through</param>
+        /// <param name="batchSizeLimitBytes">Serilog http sink pass-through</param>
+        /// <param name="queueLimitBytes">Serilog http sink pass-through</param>
         /// <param name="period">Serilog http sink pass-through</param>
         /// <param name="restrictedToMinimumLevel">Serilog http sink pass-through</param>
         /// <param name="propertiesPrefix">A prefix for properties derived from the serilog log template arguments</param>
@@ -30,8 +31,8 @@ namespace Serilog
             string ingestUrl,
             string applicationId = null,
             string hostName = null,
-            int? batchPostingLimit = null,
-            int? queueLimit = null,
+            int? batchSizeLimitBytes = null,
+            int? queueLimitBytes = null,
             TimeSpan? period = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string propertiesPrefix = "attr.",
@@ -49,8 +50,8 @@ namespace Serilog
                 Environment.GetEnvironmentVariable("ASPNET_ENVIRONMENT");
 
             return sinkConfiguration.Http(ingestUrl,
-                batchPostingLimit: batchPostingLimit ?? 50,
-                queueLimit: queueLimit ?? 100,
+                batchSizeLimitBytes: batchSizeLimitBytes,
+                queueLimitBytes: queueLimitBytes,
                 period: period ?? TimeSpan.FromSeconds(15),
                 textFormatter: new DynatraceTextFormatter(applicationId, hostName, envName, propertiesPrefix, customAttributes),
                 batchFormatter: new DynatraceBatchFormatter(),
@@ -65,8 +66,9 @@ namespace Serilog
         /// <param name="ingestUrl">The endpoint for log ingestion, usually of the form "https://{instanceId}.live.dynatrace.com/api/v2/logs/ingest"</param>
         /// <param name="applicationId">Will be populated as application.id in all log entries</param>
         /// <param name="hostName">Will be populated as host.name in all log entries</param>
-        /// <param name="batchPostingLimit">Serilog http sink pass-through</param>
-        /// <param name="bufferPathFormat">Serilog http sink pass-through</param>
+        /// <param name="batchSizeLimitBytes">Serilog http sink pass-through</param>
+        /// <param name="bufferBaseFileName">Serilog http sink pass-through</param>
+        /// <param name="bufferRollingInterval">Serilog http sink pass-through</param>
         /// <param name="period">Serilog http sink pass-through</param>
         /// <param name="restrictedToMinimumLevel">Serilog http sink pass-through</param>
         /// <param name="propertiesPrefix">A prefix for properties derived from the serilog log template arguments</param>
@@ -79,8 +81,9 @@ namespace Serilog
             string ingestUrl,
             string applicationId = null,
             string hostName = null,
-            int? batchPostingLimit = null,
-            string bufferPathFormat = "dynatrace-buffer-{Date}.json",
+            int? batchSizeLimitBytes = null,
+            string bufferBaseFileName = "dynatrace-buffer-.json",
+            BufferRollingInterval bufferRollingInterval = BufferRollingInterval.Day,
             TimeSpan? period = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string propertiesPrefix = "attr.",
@@ -97,9 +100,10 @@ namespace Serilog
                 Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ??
                 Environment.GetEnvironmentVariable("ASPNET_ENVIRONMENT");
 
-            return sinkConfiguration.DurableHttp(ingestUrl,
-                bufferPathFormat: bufferPathFormat,
-                batchPostingLimit: batchPostingLimit ?? 50,
+            return sinkConfiguration.DurableHttpUsingTimeRolledBuffers(ingestUrl,
+                batchSizeLimitBytes: batchSizeLimitBytes,
+                bufferBaseFileName: bufferBaseFileName,
+                bufferRollingInterval: bufferRollingInterval,
                 period: period ?? TimeSpan.FromSeconds(15),
                 textFormatter: new DynatraceTextFormatter(applicationId, hostName, envName, propertiesPrefix, customAttributes),
                 batchFormatter: new DynatraceBatchFormatter(),

--- a/DynatraceHttpClient.cs
+++ b/DynatraceHttpClient.cs
@@ -1,8 +1,9 @@
-using System;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Serilog.Sinks.Http;
 
 namespace Serilog.Sinks.Dynatrace
@@ -17,9 +18,14 @@ namespace Serilog.Sinks.Dynatrace
 
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Api-Token", accessToken);
         }
-
-        public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content) 
+        
+        public void Configure(IConfiguration configuration)
         {
+        }
+
+        public async Task<HttpResponseMessage> PostAsync(string requestUri, Stream contentStream)
+        {
+            var content = new StreamContent(contentStream);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = Encoding.UTF8.WebName };
             return await client.PostAsync(requestUri, content).ConfigureAwait(false);
         } 

--- a/Serilog.Sinks.Dynatrace.csproj
+++ b/Serilog.Sinks.Dynatrace.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Description>Serilog Sink that sends log events to Dynatrace https://www.dynatrace.com/</Description>
     <PackageId>Serilog.Sinks.Dynatrace</PackageId>
     <PackageTags>dynatrace;serilog;sink;logging</PackageTags>
@@ -9,12 +9,12 @@
     <RepositoryUrl>https://github.com/iojancode/Serilog.Sinks.Dynatrace</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.0.7</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Http" Version="5.1.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
     <None Include="README.md" Pack="true" PackagePath="." />
   </ItemGroup>
 


### PR DESCRIPTION
Hi! I just spiked this out after receiving [a report that the latest Seq and Dynatrace sinks are incompatible](https://github.com/datalust/serilog-sinks-seq/issues/214#issuecomment-2008122631). There have been a few updates to Serilog.Sinks.Http and its dependencies that cause some challenges for consumers who pull in the latest versions of these.

This PR tentatively bumps the major version to 2.x, due to:

 * .NET Framework support moving from `net46` to `net462`,
 * Slight changes in sink buffering filename, batch limit, and queue limit parameters, and
 * Aforementioned major version bumps for the main dependencies.

Please don't feel any obligation to look at this one, but if it's useful and can be merged I'm happy addressing any feedback you might have.

Cheers!
Nick